### PR TITLE
FIX Ensure regex replacements are mapped through

### DIFF
--- a/code/services/MisdirectionService.php
+++ b/code/services/MisdirectionService.php
@@ -175,10 +175,13 @@ class MisdirectionService {
 		$counter = 1;
 		$redirect = $map->getLink();
 		$chain = array(
-			array_merge(array(
-				'Counter' => $counter,
-				'RedirectLink' => $map->getLinkSummary()
-			), $map->toMap())
+			array_merge(
+				$map->toMap(),
+				array(
+					'Counter' => $counter,
+					'RedirectLink' => $map->getLinkSummary()
+				)
+			)
 		);
 
 		// Determine the next link mapping.

--- a/code/tests/TestMisdirectedLinkMapping.php
+++ b/code/tests/TestMisdirectedLinkMapping.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @author marcus
+ */
+class TestMisdirectedLinkMapping extends SapphireTest {
+	
+	public function testRegexUrlReplacement() {
+		$mapping = new LinkMapping(array(
+			'LinkType'		=> 'Regular Expression',
+			'MappedLink'	=> '^case-study(.*)',
+			'RedirectLink'	=> 'our-stories/case-studies?source=\\1',
+		));
+		
+		$mapping->setMatchedURL('case-study-blood-stage-malaria-vaccine');
+		
+		$link = $mapping->getLink();
+		
+		$this->assertEquals('/our-stories/case-studies?source=-blood-stage-malaria-vaccine', $link);
+		
+	}
+	
+	public function testMappingToResult() {
+		$mapping = new LinkMapping(array(
+			'LinkType'		=> 'Regular Expression',
+			'MappedLink'	=> '^case-study(.*)',
+			'RedirectLink'	=> 'our-stories/case-studies?source=\\1',
+		));
+		$mapping->setMatchedURL('case-study-blood-stage-malaria-vaccine');
+		
+		$service = singleton('MisdirectionService');
+		
+		$out = $service->getRecursiveMapping($mapping, null, true);
+		
+		$this->assertEquals(1, count($out));
+		$this->assertEquals('our-stories/case-studies?source=-blood-stage-malaria-vaccine', $out[0]['RedirectLink']);
+	}
+}


### PR DESCRIPTION
Regex replacements were being overwritten by mis-ordered array_merge call
that overwrote the calculated result with the initial un-replaced value
