### PR TITLE
FIX Ensure a controller exists before being referenced

### DIFF
--- a/code/services/MisdirectionService.php
+++ b/code/services/MisdirectionService.php
@@ -76,7 +76,7 @@ class MisdirectionService {
 
 		// Enforce any hostname restriction that may have been defined.
 
-		if(is_null($host)) {
+		if(is_null($host) && Controller::curr()) {
 			$host = Controller::curr()->getRequest()->getHeader('Host');
 		}
 		$matches = $matches->where("(HostnameRestriction IS NULL) OR (HostnameRestriction = '" . Convert::raw2sql($host) . "')");


### PR DESCRIPTION
In some cases (particularly static cache generation) misdirection can kick in
when there's not actually a controller ready
