### PR TITLE
FIX Set empty response body for redirects

### DIFF
--- a/code/requestfilters/MisdirectionRequestFilter.php
+++ b/code/requestfilters/MisdirectionRequestFilter.php
@@ -97,7 +97,7 @@ class MisdirectionRequestFilter implements RequestFilter {
 			}
 
 			// Update the response using the link mapping redirection.
-
+            $response->setBody('');
 			$response->redirect($map->getLink(), $responseCode);
 		}
 
@@ -113,7 +113,7 @@ class MisdirectionRequestFilter implements RequestFilter {
 			}
 
 			// Update the response using the fallback, enforcing no further redirection.
-
+            $response->setBody('');
 			$response->redirect($fallback['link'], $responseCode);
 		}
 


### PR DESCRIPTION
Some combinations of modules can cause upstream caches to grab the response
body and make use of it; if redirecting, just ensure that it's cleared out
