### PR TITLE
fix(404): Allow a user to call $this->httpError(404) and still get proper 'misdirection' behaviour.

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -11,3 +11,6 @@ SiteTree:
 SiteConfig:
   extensions:
     - 'MisdirectionFallbackExtension'
+Controller:
+  extensions:
+    - 'MisdirectionControllerExtension'

--- a/code/extensions/MisdirectionControllerExtension.php
+++ b/code/extensions/MisdirectionControllerExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+class MisdirectionControllerExtension extends Extension {
+
+	public function onBeforeHTTPError($statusCode, $request) {
+		if ($statusCode == 404) 
+		{
+			$service = Injector::inst()->get('MisdirectionService');
+			$fallback = $service->determineFallback($request->getURL(true));
+			if ($fallback)
+			{
+				$response = $this->owner->getResponse();
+				$response->redirect($fallback['link'], 302);
+				throw new SS_HTTPResponse_Exception($response);
+			}
+		}
+	}
+}

--- a/code/extensions/MisdirectionControllerExtension.php
+++ b/code/extensions/MisdirectionControllerExtension.php
@@ -5,8 +5,19 @@ class MisdirectionControllerExtension extends Extension {
 	public function onBeforeHTTPError($statusCode, $request) {
 		if ($statusCode == 404) 
 		{
+			// Get URL and remove the last URLSegment (ie. the current page)
+			$dirParts = explode('/', $request->getURL(true));
+			array_pop($dirParts);
+			$fallbackURL = implode('/', $dirParts);
+			// HACK(Jake): 'determineFallback' requires last URLSegment to not exist in SiteTree
+			//			   (as of 2016-06-01)
+			$fallbackURL .= '/ ';
+
+			/**
+			 * @var MisdirectionService
+			 */
 			$service = Injector::inst()->get('MisdirectionService');
-			$fallback = $service->determineFallback($request->getURL(true));
+			$fallback = $service->determineFallback($fallbackURL);
 			if ($fallback)
 			{
 				$response = $this->owner->getResponse();


### PR DESCRIPTION
fix(404): Allow a user to call $this->httpError(404) and still get proper 'misdirection' behaviour.
