### PR TITLE
encode blanks in URL before determine if it is an external one

### DIFF
--- a/code/services/MisdirectionService.php
+++ b/code/services/MisdirectionService.php
@@ -29,6 +29,7 @@ class MisdirectionService {
 	public static function is_external_URL($URL) {
 
 		$URL = trim($URL, '/?!"#$%&\'()*+,-.@:;<=>[\\]^_`{|}~');
+		$URL = preg_replace('(\s)', '%20', $URL);
 		return preg_match('%^(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?$%iu', $URL);
 	}
 


### PR DESCRIPTION
Hello,

we're having some problems in using a regex link mapping for URLs like `www.unibz.it/foo/Some%20File` to redirect `another.host.unibz.it/Some%File`

It seems third party validation to determine external URLs fails because the input is already decoded and %20 are substituted by blanks.

The regex in `is_external_URL()` in class `MisdirectionService` explicitly checks for non-blanks in the last non-matching group `(?:[^\s]*)`

I don't know if there is the possibility not to decode the URL before doing the check, or if it is the right way to do it, but this fix works for us at the moment.

Do you see any problems in this approach?
Is there another way to solve the problem?

Thanks
Regards


Giulio