### PR TITLE
Add a try/catch to the controller call

### DIFF
--- a/code/extensions/SiteTreeMisdirectionExtension.php
+++ b/code/extensions/SiteTreeMisdirectionExtension.php
@@ -49,10 +49,17 @@ class SiteTreeMisdirectionExtension extends DataExtension {
 	public function onBeforeWrite() {
 
 		parent::onBeforeWrite();
-
-		// Retrieve the vanity mapping URL, where this is only possible using the POST variable.
-
-		$vanityURL = (is_null($controller = Controller::curr()) || is_null($URL = $controller->getRequest()->postVar('VanityURL'))) ? $this->owner->VanityMapping()->MappedLink : $URL;
+		// Add exception handling (helps when running Behat tests that create Page as fixtures)
+		try {
+			// Retrieve the vanity mapping URL, where this is only possible using the POST variable.
+			if(is_null($controller = Controller::curr()) || is_null($URL = $controller->getRequest()->postVar('VanityURL'))) {
+				$vanityURL = $this->owner->VanityMapping()->MappedLink;
+			} else {
+				$vanityURL = $URL;
+			}
+		} catch (Exception $e){
+			$vanityURL = false;
+		}
 		$mappingExists = $this->owner->VanityMapping()->exists();
 
 		// Determine whether the vanity mapping URL has been updated.


### PR DESCRIPTION
We had found that when running Behat tests and we created a Page object as a fixture the onBeforeWrite would cascade to here. Given at the time of execution there is no controller it causes a failure in the Behat test.

This attempts to catch the exception of there being no current controller and handle it so that the Behat test can continue to run.

May need a unit test to ensure the original behaviour here works as expected when there is a controller. 