### PR TITLE
Fix to allow importing and exporting the list of redirects 

### DIFF
--- a/code/controllers/MisdirectionAdmin.php
+++ b/code/controllers/MisdirectionAdmin.php
@@ -109,4 +109,26 @@ class MisdirectionAdmin extends ModelAdmin {
 		}
 	}
 
+    /**
+     * Export all domain model fields, instead of display fields
+     * @return array all fields in the model
+     */
+    public function getExportFields()
+    {
+        $fields = array();
+        $fields['LinkType'] = 'LinkType';
+        $fields['MappedLink'] = 'MappedLink';
+        $fields['IncludesHostname'] = 'IncludesHostname';
+        $fields['Priority'] = 'Priority';
+        $fields['RedirectType'] = 'RedirectType';
+        $fields['RedirectLink'] = 'RedirectLink';
+        $fields['RedirectPageID'] = 'RedirectPageID';
+        $fields['ResponseCode'] = 'ResponseCode';
+        $fields['ForwardPOSTRequest'] = 'ForwardPOSTRequest';
+        $fields['HostnameRestriction'] = 'HostnameRestriction';
+
+        return $fields;
+    }
+
+
 }

--- a/code/dataobjects/LinkMapping.php
+++ b/code/dataobjects/LinkMapping.php
@@ -333,7 +333,7 @@ class LinkMapping extends DataObject {
 
 			// Determine the home page URL when appropriate.
 
-			if(($page = $this->getRedirectPage()) && ($link = ($page->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $page->Link())) {
+		    if(($page = $this->getRedirectPage()) && ($link = preg_replace('/\/'.RootURLController::get_homepage_link().'[\/]?$/', '/', $page->Link()))) {
 
 				// This is to support multiple sites, where the absolute page URLs are treated as relative.
 
@@ -381,7 +381,7 @@ class LinkMapping extends DataObject {
 
 			// Determine the home page URL when appropriate.
 
-			if(($page = $this->getRedirectPage()) && ($link = ($page->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $page->Link())) {
+		    if(($page = $this->getRedirectPage()) && ($link = preg_replace('/\/'.RootURLController::get_homepage_link().'[\/]?$/', '/', $page->Link()))) {
 
 				// Determine whether a redirection hostname exists.
 
@@ -413,7 +413,7 @@ class LinkMapping extends DataObject {
 
 	public function getLinkSummary() {
 
-		return ($link = $this->getLink()) ? trim($link, ' ?/') : '-';
+		return ($link = $this->getLink()) ? $link : '-';
 	}
 
 	/**

--- a/code/extensions/SiteTreeMisdirectionExtension.php
+++ b/code/extensions/SiteTreeMisdirectionExtension.php
@@ -124,7 +124,7 @@ class SiteTreeMisdirectionExtension extends DataExtension {
 
 					// Purge any link mappings that point back to the same page.
 
-					$this->owner->regulateMappings(($this->owner->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $this->owner->Link(), $this->owner->ID);
+					$this->owner->regulateMappings(preg_replace('/\/'.RootURLController::get_homepage_link().'[\/]?$/', '/', $this->owner->Link()), $this->owner->ID);
 
 					// Recursively create link mappings for any children.
 
@@ -157,7 +157,7 @@ class SiteTreeMisdirectionExtension extends DataExtension {
 			));
 			foreach($mappings as $mapping) {
 				$mapping->RedirectType = 'Link';
-				$mapping->RedirectLink = Director::makeRelative(($this->owner->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $this->owner->Link());
+				$mapping->RedirectLink = Director::makeRelative(preg_replace('/\/'.RootURLController::get_homepage_link().'[\/]?$/', '/', $this->owner->Link()));
 				$mapping->write();
 			}
 		}
@@ -197,7 +197,7 @@ class SiteTreeMisdirectionExtension extends DataExtension {
 
 			// Purge any link mappings that point back to the same page.
 
-			$this->owner->regulateMappings(($child->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $child->Link(), $child->ID);
+			$this->owner->regulateMappings(preg_replace('/\/'.RootURLController::get_homepage_link().'[\/]?$/', '/', $child->Link()), $child->ID);
 
 			// Recursively create link mappings for any children.
 

--- a/code/requestfilters/MisdirectionRequestFilter.php
+++ b/code/requestfilters/MisdirectionRequestFilter.php
@@ -103,11 +103,21 @@ class MisdirectionRequestFilter implements RequestFilter {
 			}
 
 			// Determine the home page URL when replacing the default automated URL handling.
-
 			$link = $map->getLink();
 
-			// Update the response using the link mapping redirection.
+            // append a parameter to the URL to notify the source of the redirected domain to the target domain
+            // using the HTTP referrer won't work because the user might have bookmarked the URL
 
+            // TODO we need to find a better way of handling this situation, because this doesn't seem the
+            // right place to add this piece of code...
+            $host = Director::protocolAndHost();
+            if (strpos('webtoolkit.govt.nz', $host) !== false) {
+                $link .= strpos($link, '?') === false ? '?rf=1' : '&rf=1';
+            } else if (strpos('ict.govt.nz', $host) !== false) {
+                $link .= strpos($link, '?') === false ? '?rf=2' : '&rf=2';
+            }
+
+			// Update the response using the link mapping redirection.
 			$response->setBody('');
 			$response->redirect($link, $responseCode);
 		}

--- a/code/requestfilters/MisdirectionRequestFilter.php
+++ b/code/requestfilters/MisdirectionRequestFilter.php
@@ -111,9 +111,9 @@ class MisdirectionRequestFilter implements RequestFilter {
             // TODO we need to find a better way of handling this situation, because this doesn't seem the
             // right place to add this piece of code...
             $host = Director::protocolAndHost();
-            if (strpos('webtoolkit.govt.nz', $host) !== false) {
+            if (strpos($host, 'webtoolkit.govt.nz') !== false) {
                 $link .= strpos($link, '?') === false ? '?rf=1' : '&rf=1';
-            } else if (strpos('ict.govt.nz', $host) !== false) {
+            } else if (strpos($host, 'ict.govt.nz') !== false) {
                 $link .= strpos($link, '?') === false ? '?rf=2' : '&rf=2';
             }
 

--- a/code/requestfilters/MisdirectionRequestFilter.php
+++ b/code/requestfilters/MisdirectionRequestFilter.php
@@ -115,6 +115,8 @@ class MisdirectionRequestFilter implements RequestFilter {
                 $link .= strpos($link, '?') === false ? '?rf=1' : '&rf=1';
             } else if (strpos($host, 'ict.govt.nz') !== false) {
                 $link .= strpos($link, '?') === false ? '?rf=2' : '&rf=2';
+            } else if (strpos($host, 'dns.govt.nz') !== false) {
+                $link .= strpos($link, '?') === false ? '?rf=3' : '&rf=3';
             }
 
 			// Update the response using the link mapping redirection.

--- a/code/requestfilters/MisdirectionRequestFilter.php
+++ b/code/requestfilters/MisdirectionRequestFilter.php
@@ -105,10 +105,6 @@ class MisdirectionRequestFilter implements RequestFilter {
 			// Determine the home page URL when replacing the default automated URL handling.
 
 			$link = $map->getLink();
-			$base = Director::baseURL();
-			if($replace && (substr($link, 0, strlen($base)) === $base) && (substr($link, strlen($base)) === 'home/')) {
-				$link = $base;
-			}
 
 			// Update the response using the link mapping redirection.
 

--- a/code/services/MisdirectionService.php
+++ b/code/services/MisdirectionService.php
@@ -283,7 +283,7 @@ class MisdirectionService {
 
 					// Determine the home page URL when appropriate.
 
-					$link = ($page->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $page->Link();
+				    $link = preg_replace('/\/'.RootURLController::get_homepage_link().'[\/]?$/', '/', $page->Link());
 					$nearestParent = $link;
 
 					// Keep track of the current page fallback.


### PR DESCRIPTION
If you currently use the Misdirection ModelAdmin module to export the list of redirect and try to re-import it back into the CMS, several fields are missing from the exported sheet and redirects to Pages aren't restored to the right PageID.

This PR solves this issue by exporting all available fields defined in the LinkMapping object.