### PR TITLE
Fix to allow importing and exporting the list of redirects by exporti…

### DIFF
--- a/code/controllers/MisdirectionAdmin.php
+++ b/code/controllers/MisdirectionAdmin.php
@@ -109,4 +109,26 @@ class MisdirectionAdmin extends ModelAdmin {
 		}
 	}
 
+    /**
+     * Export all domain model fields, instead of display fields
+     * @return array all fields in the model
+     */
+    public function getExportFields()
+    {
+        $fields = array();
+        $fields['LinkType'] = 'LinkType';
+        $fields['MappedLink'] = 'MappedLink';
+        $fields['IncludesHostname'] = 'IncludesHostname';
+        $fields['Priority'] = 'Priority';
+        $fields['RedirectType'] = 'RedirectType';
+        $fields['RedirectLink'] = 'RedirectLink';
+        $fields['RedirectPageID'] = 'RedirectPageID';
+        $fields['ResponseCode'] = 'ResponseCode';
+        $fields['ForwardPOSTRequest'] = 'ForwardPOSTRequest';
+        $fields['HostnameRestriction'] = 'HostnameRestriction';
+
+        return $fields;
+    }
+
+
 }


### PR DESCRIPTION
If you currently use the Misdirection ModelAdmin module to export the list of redirect and try to re-import it back into the CMS, several fields are missing from the exported sheet and redirects to Pages aren't restored to the right PageID.

This PR solves this issue by exporting all available fields defined in the LinkMapping object.