### PR TITLE
Allow extra parameters based to be added based on redirected domain

### DIFF
--- a/code/controllers/MisdirectionAdmin.php
+++ b/code/controllers/MisdirectionAdmin.php
@@ -7,7 +7,10 @@
 
 class MisdirectionAdmin extends ModelAdmin {
 
-	private static $managed_models = 'LinkMapping';
+	private static $managed_models = array(
+		'LinkMapping',
+		'DomainParameter'
+	);
 
 	private static $menu_title = 'Misdirection';
 
@@ -26,14 +29,16 @@ class MisdirectionAdmin extends ModelAdmin {
 	public function getEditForm($ID = null, $fields = null) {
 
 		$form = parent::getEditForm($ID, $fields);
-		$gridfield = $form->Fields()->fieldByName($this->sanitiseClassName($this->modelClass));
+
+		$gridName = $this->sanitiseClassName($this->modelClass);
+		$gridfield = $form->Fields()->fieldByName($gridName);
 		$gridfield->getConfig()->getComponentByType('GridFieldSortableHeader')->setFieldSorting(array(
 			'RedirectTypeSummary' => 'RedirectType'
 		));
 
 		// Allow extension customisation.
-
 		$this->extend('updateMisdirectionAdminEditForm', $form);
+
 		return $form;
 	}
 
@@ -108,5 +113,36 @@ class MisdirectionAdmin extends ModelAdmin {
 			return $this->httpError(404);
 		}
 	}
+
+    /**
+     * Export all domain model fields, instead of display fields
+     * @return array all fields in the model
+     */
+    public function getExportFields()
+    {
+		$gridName = $this->sanitiseClassName($this->modelClass);
+
+		$fields = array();
+		if ($gridName === 'LinkMapping') {
+			$fields['ID'] = 'ID';
+			$fields['LinkType'] = 'LinkType';
+			$fields['MappedLink'] = 'MappedLink';
+			$fields['IncludesHostname'] = 'IncludesHostname';
+			$fields['Priority'] = 'Priority';
+			$fields['RedirectType'] = 'RedirectType';
+			$fields['RedirectLink'] = 'RedirectLink';
+			$fields['RedirectPageID'] = 'RedirectPageID';
+			$fields['ResponseCode'] = 'ResponseCode';
+			$fields['ForwardPOSTRequest'] = 'ForwardPOSTRequest';
+			$fields['HostnameRestriction'] = 'HostnameRestriction';
+		} else if ($gridName === 'DomainParameter') {
+			$fields['ID'] = 'ID';
+			$fields['SourceDomain'] = 'SourceDomain';
+			$fields['Parameters'] = 'Parameters';
+		}
+
+        return $fields;
+    }
+
 
 }

--- a/code/dataobjects/DomainParameter.php
+++ b/code/dataobjects/DomainParameter.php
@@ -1,0 +1,121 @@
+<?php
+
+class DomainParameter extends DataObject
+{
+
+	private static $db = array(
+		'SourceDomain' => 'Varchar(255)',
+		'Parameters' => 'Varchar(255)'
+	);
+
+	private static $default_sort = 'SourceDomain ASC';
+
+	private static $searchable_fields = array(
+		'SourceDomain'
+	);
+
+	private static $summary_fields = array(
+		'SourceDomain',
+		'Parameters'
+	);
+
+	private static $field_labels = array(
+		'SourceDomain' => 'Domain',
+		'Parameters' => 'Parameters To Add'
+	);
+
+	private static $priority = 'ASC';
+
+	/**
+	 *    CMS users with appropriate access may view any mappings.
+	 */
+	public function canView($member = null)
+	{
+
+		return true;
+	}
+
+	/**
+	 *    CMS administrators may edit any mappings.
+	 */
+	public function canEdit($member = null)
+	{
+
+		return Permission::checkMember($member, 'ADMIN');
+	}
+
+	/**
+	 *    CMS administrators may create any mappings.
+	 */
+	public function canCreate($member = null)
+	{
+
+		return Permission::checkMember($member, 'ADMIN');
+	}
+
+	/**
+	 *    CMS administrators may delete any mappings.
+	 */
+	public function canDelete($member = null)
+	{
+
+		return Permission::checkMember($member, 'ADMIN');
+	}
+
+	public function getTitle()
+	{
+
+		return $this->SourceDomain;
+	}
+
+	public function getCMSFields()
+	{
+
+		$fields = parent::getCMSFields();
+		Requirements::css(MISDIRECTION_PATH . '/css/misdirection.css');
+
+		// Remove any fields that are not required in their default state.
+		$fields->removeByName('SourceDomain');
+		$fields->removeByName('Parameters');
+
+		// Instantiate the required fields.
+		$fields->insertBefore(HeaderField::create(
+			'MappedLinkHeader',
+			'Add parameters to the request for a specifically redirected domain',
+			3
+		), 'SourceDomain');
+
+		$domain = TextField::create('SourceDomain', '')
+			->setRightTitle('This should <strong>not</strong> include the <strong>HTTP/S</strong> scheme')
+			->setTitle('Domain');
+		$fields->addFieldToTab('Root.Main', $domain);
+
+		$parameters = TextField::create('Parameters', '')
+			->setRightTitle('These parameters will be added to the final request, for instance: rf=1 or rf=1&x=y')
+			->setTitle('Parameters');
+		$fields->addFieldToTab('Root.Main', $parameters);
+
+		// Allow extension customisation.
+		$this->extend('updateSourceDomainCMSFields', $fields);
+
+		return $fields;
+	}
+
+	public function validate()
+	{
+
+		$result = parent::validate();
+
+		// Allow extension customisation.
+		$this->extend('validateSourceDomainMapping', $result);
+
+		return $result;
+	}
+
+	public function onBeforeWrite()
+	{
+		parent::onBeforeWrite();
+		$this->SourceDomain = strtolower($this->SourceDomain);
+	}
+
+}

--- a/code/requestfilters/MisdirectionRequestFilter.php
+++ b/code/requestfilters/MisdirectionRequestFilter.php
@@ -110,8 +110,10 @@ class MisdirectionRequestFilter implements RequestFilter {
 				$link = $base;
 			}
 
-			// Update the response using the link mapping redirection.
+            // append a parameters to the URL based on the current domain
+            $link = $this->service->updateLinkParametersForDomain($link);
 
+            // Update the response using the link mapping redirection.
 			$response->setBody('');
 			$response->redirect($link, $responseCode);
 		}

--- a/code/services/MisdirectionService.php
+++ b/code/services/MisdirectionService.php
@@ -221,6 +221,27 @@ class MisdirectionService {
 		return $testing ? $chain : $map;
 	}
 
+
+    /**
+     * Return added parameters to the redirected url based on the redirected host
+     * @param $link the current link the user will be redirected to
+     * @return string updated link with extra parameters
+     */
+    public function updateLinkParametersForDomain($link) {
+        $protocolAndHost = Director::protocolAndHost();
+        $parts = parse_url($protocolAndHost);
+        $host = $parts['host'];
+
+        $domain = DomainParameter::get()->filter('SourceDomain', $host)->first();
+
+        if (!empty($domain) && ($host === $domain->SourceDomain)) {
+            $link .= strpos($link, '?') === false ? '?' : '&';
+            $link .= $domain->Parameters;
+        }
+
+        return $link;
+    }
+
 	/**
 	 *	Determine the fallback for a URL when the CMS module is present.
 	 *


### PR DESCRIPTION
This PR allows you to add extra parameters to the redirected URL based on the redirected domain. Consider the following use-case;

1. A server setup to listen to two domains [A] and [B]. The domain [B] is some site that has content migrated to domain [A].
2. Whenever a user requests a page from domain [B], the request is redirected to site [A] using misdirection.
3. Using the new "Domain Parameters" option in misdirection, you can add parameters to the request based on the origin (domain [B]). The page the user is redirected to, can use these parameters to display - for instance - a banner to inform the user that content from domain [B] has been migrated to domain [A]

`[original request] domain.b/  -> [rewritten to] domain.a/?parameter1`