### PR TITLE
Default GridFieldFilterHeader to MappedLink and Add Misdirection Permissions

### DIFF
--- a/src/controllers/MisdirectionAdmin.php
+++ b/src/controllers/MisdirectionAdmin.php
@@ -11,14 +11,13 @@ use SilverStripe\Security\Permission;
 /**
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
-
-class MisdirectionAdmin extends ModelAdmin {
-
+class MisdirectionAdmin extends ModelAdmin
+{
 	private static $managed_models = LinkMapping::class;
 
 	private static $menu_title = 'Misdirection';
 
-	private static $menu_description = 'Create, manage and test customisable <strong>link redirection</strong> mappings.';
+	private static $menu_description = 'Create, manage and test customisable link redirection mappings.';
 
 	private static $menu_icon_class = 'font-icon-switch';
 
@@ -31,7 +30,6 @@ class MisdirectionAdmin extends ModelAdmin {
 	/**
 	 *	Update the custom summary fields to be sortable.
 	 */
-
 	public function getEditForm($ID = null, $fields = null) {
 
 		$form = parent::getEditForm($ID, $fields);
@@ -52,26 +50,22 @@ class MisdirectionAdmin extends ModelAdmin {
 	 *	@URLparameter map <{TEST_URL}> string
 	 *	@return JSON
 	 */
-
-	public function getMappingChain() {
-
-		// Restrict this functionality to administrators.
-
+	public function getMappingChain()
+	{
 		$user = Member::currentUserID();
-		if(Permission::checkMember($user, 'ADMIN')) {
+
+		if (singleton(LinkMapping::class)->canCreate()) {
 
 			// Instantiate a request to handle the link mapping.
-
 			$request = new HTTPRequest('GET', $this->getRequest()->getVar('map'));
 
 			// Retrieve the link mapping recursion stack JSON.
-
 			$testing = true;
 			$mappings = singleton(MisdirectionService::class)->getMappingByRequest($request, $testing);
+
 			$this->getResponse()->addHeader('Content-Type', 'application/json');
 
 			// JSON_PRETTY_PRINT.
-
 			return json_encode($mappings, 128);
 		}
 		else {
@@ -79,4 +73,28 @@ class MisdirectionAdmin extends ModelAdmin {
 		}
 	}
 
+	/**
+     * Export all domain model fields, instead of display fields to allow for
+	 * importing the list again
+	 *
+     * @return array
+     */
+    public function getExportFields()
+    {
+        $fields = [];
+        $fields['LinkType'] = 'LinkType';
+        $fields['MappedLink'] = 'MappedLink';
+        $fields['IncludesHostname'] = 'IncludesHostname';
+        $fields['Priority'] = 'Priority';
+        $fields['RedirectType'] = 'RedirectType';
+        $fields['RedirectLink'] = 'RedirectLink';
+        $fields['RedirectPageID'] = 'RedirectPageID';
+        $fields['ResponseCode'] = 'ResponseCode';
+        $fields['ForwardPOSTRequest'] = 'ForwardPOSTRequest';
+        $fields['HostnameRestriction'] = 'HostnameRestriction';
+
+		$this->extend('updateExportFields', $fields);
+
+        return $fields;
+    }
 }

--- a/src/objects/LinkMapping.php
+++ b/src/objects/LinkMapping.php
@@ -56,8 +56,8 @@ class LinkMapping extends DataObject {
 	private static $default_sort = 'ID DESC';
 
 	private static $searchable_fields = array(
-		'LinkType',
 		'MappedLink',
+		'LinkType',
 		'Priority',
 		'RedirectType'
 	);

--- a/src/objects/LinkMapping.php
+++ b/src/objects/LinkMapping.php
@@ -101,19 +101,28 @@ class LinkMapping extends DataObject {
 		return true;
 	}
 
-	public function canEdit($member = null) {
-
-		return Permission::checkMember($member, 'ADMIN');
+	public function canEdit($member = null)
+	{
+		return (
+			Permission::checkMember($member, 'ADMIN') ||
+			Permission::checkMember($member, 'CMS_ACCESS_nglasl\misdirection\MisdirectionAdmin')
+		);
 	}
 
-	public function canCreate($member = null, $context = array()) {
-
-		return Permission::checkMember($member, 'ADMIN');
+	public function canCreate($member = null, $context = array())
+	{
+		return (
+			Permission::checkMember($member, 'ADMIN') ||
+			Permission::checkMember($member, 'CMS_ACCESS_nglasl\misdirection\MisdirectionAdmin')
+		);
 	}
 
-	public function canDelete($member = null) {
-
-		return Permission::checkMember($member, 'ADMIN');
+	public function canDelete($member = null)
+	{
+		return (
+			Permission::checkMember($member, 'ADMIN') ||
+			Permission::checkMember($member, 'CMS_ACCESS_nglasl\misdirection\MisdirectionAdmin')
+		);
 	}
 
 	/**

--- a/src/objects/LinkMapping.php
+++ b/src/objects/LinkMapping.php
@@ -300,6 +300,7 @@ class LinkMapping extends DataObject {
 	public function onBeforeWrite() {
 
 		parent::onBeforeWrite();
+
 		$this->MappedLink = MisdirectionService::unify_URL($this->MappedLink);
 		$this->RedirectLink = trim($this->RedirectLink, ' ?/');
 		$this->HostnameRestriction = MisdirectionService::unify_URL($this->HostnameRestriction);


### PR DESCRIPTION
In SilverStripe 4.4 the new GridFieldFilterHeader uses the first searchable_field as the default search column (for better or worst) so this makes the default something that will return some results.